### PR TITLE
Status and timestamps changes

### DIFF
--- a/src/main/java/com/aforo/billablemetrics/dto/BillableMetricResponse.java
+++ b/src/main/java/com/aforo/billablemetrics/dto/BillableMetricResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 
 import com.aforo.billablemetrics.enums.BillingCriteria;
@@ -39,5 +40,9 @@ public class BillableMetricResponse {
     private BillingCriteria billingCriteria;
 
     private MetricStatus status;
+
+    private LocalDateTime createdOn;
+
+    private LocalDateTime lastUpdated;
 
 }

--- a/src/main/java/com/aforo/billablemetrics/entity/BillableMetric.java
+++ b/src/main/java/com/aforo/billablemetrics/entity/BillableMetric.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -58,8 +59,21 @@ public class BillableMetric {
     @Column(name = "status", nullable = false)
     private MetricStatus status;
 
+    @Column(name = "created_on")
+    private LocalDateTime createdOn;
+
+    @Column(name = "last_updated")
+    private LocalDateTime lastUpdated;
+
     @PrePersist
     void prePersist() {
         if (status == null) status = MetricStatus.DRAFT;
+        if (createdOn == null) createdOn = LocalDateTime.now();
+        if (lastUpdated == null) lastUpdated = createdOn;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        lastUpdated = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/aforo/billablemetrics/mapper/BillableMetricMapper.java
+++ b/src/main/java/com/aforo/billablemetrics/mapper/BillableMetricMapper.java
@@ -37,6 +37,8 @@ public interface BillableMetricMapper {
     @Mapping(source = "usageConditions",    target = "usageConditions")
     @Mapping(source = "billingCriteria",    target = "billingCriteria")
     @Mapping(source = "status",             target = "status") // ✨ NEW: map status (DRAFT/ACTIVE) to response
+    @Mapping(source = "createdOn",          target = "createdOn")
+    @Mapping(source = "lastUpdated",        target = "lastUpdated")
     @Mapping(target = "productName",        ignore = true)
     BillableMetricResponse toResponse(BillableMetric entity);
 

--- a/src/main/java/com/aforo/billablemetrics/service/BillableMetricServiceImpl.java
+++ b/src/main/java/com/aforo/billablemetrics/service/BillableMetricServiceImpl.java
@@ -32,6 +32,7 @@ public class BillableMetricServiceImpl implements BillableMetricService {
         // Soft checks only: productId/uom if present
         if (request.getProductId() != null) {
             validateProductExists(request.getProductId());
+            validateProductActive(request.getProductId());
             if (request.getUnitOfMeasure() != null) {
                 validateUOMMatchesProductType(request.getProductId(), request.getUnitOfMeasure());
             }
@@ -105,6 +106,8 @@ public class BillableMetricServiceImpl implements BillableMetricService {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "metricName is required");
         if (metric.getProductId() == null)
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "productId is required");
+        // Product must be ACTIVE to finalize the metric
+        validateProductActive(metric.getProductId());
         if (metric.getUnitOfMeasure() == null)
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "unitOfMeasure is required");
         if (metric.getAggregationFunction() == null)
@@ -163,6 +166,12 @@ public class BillableMetricServiceImpl implements BillableMetricService {
     private void validateProductExists(Long productId) {
         if (!productClient.productExists(productId)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid productId: " + productId);
+        }
+    }
+
+    private void validateProductActive(Long productId) {
+        if (!productClient.isProductActive(productId)) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Product must be ACTIVE to create or finalize billable metrics");
         }
     }
 

--- a/src/main/java/com/aforo/billablemetrics/webclient/ProductServiceClient.java
+++ b/src/main/java/com/aforo/billablemetrics/webclient/ProductServiceClient.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -59,12 +60,29 @@ public class ProductServiceClient {
     }
 }
 
+    public boolean isProductActive(Long productId) {
+        try {
+            String status = productServiceWebClient.get()
+                    .uri("/{id}", productId)
+                    .retrieve()
+                    .bodyToMono(ProductResponse.class)
+                    .map(ProductResponse::getStatus)
+                    .block();
+            return status != null && "ACTIVE".equalsIgnoreCase(status);
+        } catch (Exception e) {
+            log.warn("Failed to fetch product status: {}", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Cannot fetch product status for ID: " + productId);
+        }
+    }
+
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 private static class ProductResponse {
     private Long productId;
     private String productName;
     private String productType; // 🔥 ensure backend sends this
+    private String status; // product status from Product API
 }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
+  jackson:
+    date-format: dd MMM, yyyy HH:mm z
+    time-zone: Asia/Kolkata
   liquibase:
     enabled: true
     change-log: classpath:db/changelog/changelog-master.yml
@@ -14,6 +17,3 @@ application:
   name: billable-metrics-service
 server:
   port: 8081
-  jackson:
-    date-format: dd MMM, yyyy HH:mm z
-    time-zone: Asia/Kolkata

--- a/src/main/resources/db/changelog/changelog-master.yml
+++ b/src/main/resources/db/changelog/changelog-master.yml
@@ -7,3 +7,5 @@ databaseChangeLog:
       file: db/changelog/changes/003-create-metricstatus.yml
   - include:
       file: db/changelog/changes/004-nullify-new-columns.yml
+  - include:
+      file: db/changelog/changes/005-add-audit-columns.yml

--- a/src/main/resources/db/changelog/changes/005-add-audit-columns.yml
+++ b/src/main/resources/db/changelog/changes/005-add-audit-columns.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-created-lastupdated-columns
+      author: aforo
+      changes:
+        - addColumn:
+            tableName: billable_metric
+            columns:
+              - column:
+                  name: created_on
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: true
+              - column:
+                  name: last_updated
+                  type: TIMESTAMP
+                  constraints:
+                    nullable: true


### PR DESCRIPTION
Added createdOn and lastUpdated fields and added logic where if the status of the product is active then only the billable metrics can be created. If the status is in draft the creation of billable metrics is not possible. 